### PR TITLE
fix: pad ECDSA r||s signatures to fixed 64-byte width (flaky macOS crypto tests)

### DIFF
--- a/internal/attestation/signer.go
+++ b/internal/attestation/signer.go
@@ -44,8 +44,17 @@ func (s *EphemeralSigner) Sign(data []byte) (signature []byte, publicKey crypto.
 		return nil, nil, fmt.Errorf("failed to sign: %w", err)
 	}
 
-	// Encode signature (r || s)
-	signature = append(r.Bytes(), sigS.Bytes()...)
+	// Encode signature as fixed-width r || s, padding each value to the
+	// curve's byte size (32 bytes for P-256). big.Int.Bytes() strips
+	// leading zero bytes, so when r or s has a high zero byte (~1/256 each)
+	// the concatenation would be shorter than 64 bytes and the verifier,
+	// which splits at a fixed 32-byte boundary, would reject it. This is the
+	// source of intermittent "invalid signature length" verification
+	// failures. FillBytes guarantees a constant-width encoding.
+	byteLen := (s.privateKey.Curve.Params().BitSize + 7) / 8
+	signature = make([]byte, 2*byteLen)
+	r.FillBytes(signature[:byteLen])
+	sigS.FillBytes(signature[byteLen:])
 
 	return signature, &s.privateKey.PublicKey, nil
 }

--- a/internal/authz/audit_signed_test.go
+++ b/internal/authz/audit_signed_test.go
@@ -41,7 +41,14 @@ func (m *mockSigner) Sign(data []byte) ([]byte, []byte, error) {
 		return nil, nil, err
 	}
 
-	signature := append(r.Bytes(), s.Bytes()...)
+	// Encode as fixed-width r || s. big.Int.Bytes() strips leading zero
+	// bytes, which intermittently yields <64-byte signatures that the
+	// verifier (which splits at a fixed 32-byte boundary) rejects. FillBytes
+	// guarantees a constant-width encoding matching AuditVerifier.Verify.
+	byteLen := (m.privateKey.Curve.Params().BitSize + 7) / 8
+	signature := make([]byte, 2*byteLen)
+	r.FillBytes(signature[:byteLen])
+	s.FillBytes(signature[byteLen:])
 
 	publicKeyBytes, err := x509.MarshalPKIXPublicKey(&m.privateKey.PublicKey)
 	if err != nil {


### PR DESCRIPTION
## Problem

The `Test (macOS)` CI leg (runs `go test -race ./...` on push-to-main) failed **non-deterministically** — a different crypto test each run (e.g. `TestSignedAuditLogger_Integration` in `internal/authz`, `TestVerifyValidAttestation` in `internal/attestation`). Linux passed; macOS flaked. Pre-existing, unrelated to the nox/warden migration.

## Root cause

Classic ECDSA `r || s` short-encoding bug. Two signers encoded P-256 signatures as:

```go
signature := append(r.Bytes(), s.Bytes()...)
```

`big.Int.Bytes()` returns the **minimal** big-endian encoding with leading zero bytes stripped. Whenever `r` or `s` has a high zero byte (~1/256 each, so ~1/128 per signature) the concatenation is **shorter than 64 bytes**. Both verifiers require exactly 64 bytes and split at a fixed 32-byte boundary:

```go
if len(signature) != 64 { return "invalid signature length" }
r := new(big.Int).SetBytes(signature[:32])
s := new(big.Int).SetBytes(signature[32:])
```

So a short encoding fails with `invalid signature length: 63 (expected 64)`; a coincidentally-64-but-misaligned one fails with `signature verification failed`. A fresh key is generated and data signed on every test run, so the failure is random per run — reproduced locally as `invalid signature length: 63` in `internal/authz` at `-count=50`.

Affected sites:
- `internal/attestation/signer.go` — `EphemeralSigner.Sign()` (**product code**; a genuine correctness bug in the signer)
- `internal/authz/audit_signed_test.go` — `mockSigner.Sign()` (test helper)

The existing `internal/vault` and `internal/awssm` signers already pad to 32 bytes via `copy(sig[32-len(rBytes):32], rBytes)` and were unaffected.

## Fix

Encode `r` and `s` with `big.Int.FillBytes` into a fixed curve-width buffer (32 bytes for P-256), guaranteeing a constant 64-byte `r||s` encoding that the verifiers accept.

## Verification (local, on macOS)

macOS runners are label-gated in `ci.yml` (`test-macos` label opts a PR in), so I added that label to exercise the macOS leg on this PR. In addition, local high-count stress on macOS (Apple Silicon, go1.26):

- `go test -race -count=200 ./internal/authz/... ./internal/attestation/...` — **0 failures**
- `go test -race -count=100 -shuffle=on ./internal/authz/... ./internal/attestation/...` — **0 failures**
- `go test -race ./...` (count=1, matches CI) — **green**
- `go build ./...`, `go vet ./...`, `gofmt -l`, `golangci-lint run` — clean

(A `-race -count=50 -shuffle=on ./...` whole-module run surfaced two unrelated `-count>1` artifacts — `internal/metrics` prometheus global-registry double-registration and an `internal/quickstart` 10-min timeout — both pass at `count=1` and do not occur in CI. Out of scope for this fix.)

https://claude.ai/code/session_01XsciE5KjxtMrHimxWxBVFS