### PR TITLE
fix(ci): build the website on Node 22, which Astro requires

### DIFF
--- a/.github/workflows/deploy-website.yml
+++ b/.github/workflows/deploy-website.yml
@@ -30,7 +30,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
-          node-version: '20'
+          node-version: '22'
           cache: 'npm'
           cache-dependency-path: website/package-lock.json
 


### PR DESCRIPTION
Deploy Website has failed since **2026-05-09** — three consecutive runs, last success 2026-01-16:

```
Node.js v20.20.2 is not supported by Astro!
Please upgrade Node.js to a supported version: ">=22.12.0"
```

The workflow pins `node-version: '20'`. Astro raised its floor and nothing followed, so **the published site has been frozen at the January build for four months** while every run stated the reason plainly in a log nobody opened.

Verified locally: `npm ci && npm run build` completes and emits 2 pages.

Found while checking whether #47 had caused it. It had not — #47 only pinned action SHAs and never touched this line.

https://claude.ai/code/session_01CKxbiYE7cJ4PBbsBjarX6D